### PR TITLE
Depreciated tags in forms

### DIFF
--- a/templates/forms/0_adminmail.tpl
+++ b/templates/forms/0_adminmail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>formicula_admin_html_email</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/0_usermail.tpl
+++ b/templates/forms/0_usermail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>{gt text='Contact our team'}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/1_adminmail.tpl
+++ b/templates/forms/1_adminmail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>formicula_admin_html_email</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/1_usermail.tpl
+++ b/templates/forms/1_usermail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>{gt text='Apply online!'}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/2_adminmail.tpl
+++ b/templates/forms/2_adminmail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>formicula_admin_html_email</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/2_usermail.tpl
+++ b/templates/forms/2_usermail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>{gt text='Contact our team'}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/3_adminmail.tpl
+++ b/templates/forms/3_adminmail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>formicula_admin_html_email</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>

--- a/templates/forms/3_usermail.tpl
+++ b/templates/forms/3_usermail.tpl
@@ -3,7 +3,7 @@
     <head>
         <title>{gt text='Make a reservation'}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <base href="{getbaseurl}" />
+        <base href="{$baseurl}" />
     </head>
     <body>
         <p>


### PR DESCRIPTION
The bug appears in sent mail as warnings.
This happens in Zikula 1.4, and in Zikula 1.3, if compatability layer is off in config.php.

This PR `replaces use of  ```{getbaseurl}``` with ```{$baseurl}``` in tpl files.